### PR TITLE
상품 주문, 목록, 취소 기능 개발

### DIFF
--- a/jpashop/src/main/java/jpabook/jpashop/Service/OrderService.java
+++ b/jpashop/src/main/java/jpabook/jpashop/Service/OrderService.java
@@ -9,6 +9,7 @@ import jpabook.jpashop.domain.OrderItem;
 import jpabook.jpashop.repository.ItemRepository;
 import jpabook.jpashop.repository.MemberRepository;
 import jpabook.jpashop.repository.OrderRepository;
+import jpabook.jpashop.repository.OrderSearch;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,5 +49,7 @@ public class OrderService {
         order.cancel();
     }
     //검색
-//    public List<Order> findOrders(OrderSearch orderSearch){return orderRepository.findAll(orderSearch);}
+    public List<Order> findOrders(OrderSearch orderSearch){
+        return orderRepository.findAllByCriteria(orderSearch);
+    }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/controller/OrderController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/controller/OrderController.java
@@ -1,0 +1,56 @@
+package jpabook.jpashop.controller;
+
+import jpabook.jpashop.Service.ItemService;
+import jpabook.jpashop.Service.MemberService;
+import jpabook.jpashop.Service.OrderService;
+import jpabook.jpashop.domain.Item;
+import jpabook.jpashop.domain.Member;
+import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.repository.OrderSearch;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class OrderController {
+    private final OrderService orderService;
+    private final MemberService memberService;
+    private final ItemService itemService;
+
+    @GetMapping("/order")
+    public String createForm(Model model) {
+        List<Member> members = memberService.findMembers();
+        List<Item> items = itemService.findItems();
+
+        model.addAttribute("members", members);
+        model.addAttribute("items", items);
+        return "order/orderForm";
+    }
+
+    @PostMapping("/order")
+    public String order(@RequestParam("memberId") Long memberId,
+                        @RequestParam("itemId") Long itemId,
+                        @RequestParam("count") Integer count)
+    {
+            orderService.order(memberId,itemId,count);
+            return "redirect:/orders";
+    }
+
+    @GetMapping("/orders")
+    public String orderList(@ModelAttribute("orderSearch")OrderSearch orderSearch,Model model){
+        List<Order> orders = orderService.findOrders(orderSearch);
+        model.addAttribute("orders",orders);
+        return "order/orderList";
+    }
+
+    @PostMapping("/orders/{orderId}/cancel")
+    public String orderCancel(@PathVariable("orderId")Long orderId){
+        orderService.cancelOrder(orderId);
+        return "redirect:/orders";
+    }
+}
+

--- a/jpashop/src/main/resources/templates/order/orderForm.html
+++ b/jpashop/src/main/resources/templates/order/orderForm.html
@@ -1,0 +1,37 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="fragments/header :: header"></head>
+<body>
+<div class="container">
+    <div th:replace="fragments/bodyHeader :: bodyHeader"></div>
+    <form role="form" action="/order" method="post">
+        <div class="form-group">
+            <label for="member">주문회원</label>
+            <select name="memberId" id="member" class="form-control">
+                <option value="">회원선택</option>
+                <option th:each="member : ${members}"
+                        th:value="${member.id}"
+                        th:text="${member.name}" />
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="item">상품명</label>
+            <select name="itemId" id="item" class="form-control">
+                <option value="">상품선택</option>
+                <option th:each="item : ${items}"
+                        th:value="${item.id}"
+                        th:text="${item.name}" />
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="count">주문수량</label>
+            <input type="number" name="count" class="form-control" id="count"
+                   placeholder="주문 수량을 입력하세요">
+        </div>
+        <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+    <br/>
+    <div th:replace="fragments/footer :: footer"></div>
+</div> <!-- /container -->
+</body>
+</html>

--- a/jpashop/src/main/resources/templates/order/orderList.html
+++ b/jpashop/src/main/resources/templates/order/orderList.html
@@ -1,0 +1,69 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="fragments/header :: header"></head>
+<body>
+<div class="container">
+    <div th:replace="fragments/bodyHeader :: bodyHeader"></div>
+    <div>
+        <div>
+            <form th:object="${orderSearch}" class="form-inline">
+                <div class="form-group mb-2">
+                    <input type="text" th:field="*{memberName}" class="form-control" placeholder="회원명"/>
+                </div>
+                <div class="form-group mx-sm-1 mb-2">
+                    <select th:field="*{orderStatus}" class="form-control">
+                        <option value="">주문상태</option>
+                        <option th:each=
+                                        "status : ${T(jpabook.jpashop.domain.OrderStatus).values()}"
+                                th:value="${status}"
+                                th:text="${status}">option
+                        </option>
+                    </select>
+                </div>
+                <button type="submit" class="btn btn-primary mb-2">검색</button>
+            </form>
+        </div>
+        <table class="table table-striped">
+            <thead>
+            <tr>
+                <th>#</th>
+                <th>회원명</th>
+                <th>대표상품 이름</th>
+                <th>대표상품 주문가격</th>
+                <th>대표상품 주문수량</th>
+                <th>상태</th>
+                <th>일시</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="order : ${orders}">
+                <td th:text="${order.id}"></td>
+                <td th:text="${order.member.name}"></td>
+                <td th:text="${order.orderItems[0].item.name}"></td>
+                <td th:text="${order.orderItems[0].orderPrice}"></td>
+                <td th:text="${order.orderItems[0].count}"></td>
+                <td th:text="${order.status}"></td>
+                <td th:text="${#temporals.format(order.orderDate,'yyyy-MM-dd HH시 mm분 ss초')}"></td>
+                <td>
+                    <a th:if="${order.status.name() == 'ORDER'}" href="#"
+                       th:href="'javascript:cancel('+${order.id}+')'"
+                       class="btn btn-danger">CANCEL</a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <div th:replace="fragments/footer :: footer"></div>
+</div> <!-- /container -->
+</body>
+<script>
+    function cancel(id) {
+        var form = document.createElement("form");
+        form.setAttribute("method", "post");
+        form.setAttribute("action", "/orders/" + id + "/cancel");
+        document.body.appendChild(form);
+        form.submit();
+    }
+</script>
+</html>


### PR DESCRIPTION
this closes #13 
## 주문 실행
- 주문할 회원과 상품 그리고 수량을 선택해서 Submit 버튼을 누르면 `/order` URL을 POST 방식으로 호출
- 컨트롤러의 `order()` 메서드 실행
- 이 메서드는 고객 식별자 `memberId` ,주문할 상품 식별자 `itemId` , 수량 `count` 정보를 받아서 주문 서비스에  주문을 요청
- 주문이 끝나면 상품 주문 내역이 있는 `/orders` URL로 리다이렉트 