### PR TITLE
주문API V1 개발

### DIFF
--- a/jpashop/build.gradle
+++ b/jpashop/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-devtools'
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.6'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5'
 	//쿼리 파라미터를 로그로 보기
 	//참고: 쿼리 파라미터를 로그로 남기는 외부 라이브러리는 시스템 자원을 사용하므로,
 	// 개발 단계에서는 편하게 사용해도 된다. 하지만 운영시스템에 적용하려면 꼭 성능테스트를 하고 사용하는 것이 좋다.

--- a/jpashop/src/main/java/jpabook/jpashop/InitDb.java
+++ b/jpashop/src/main/java/jpabook/jpashop/InitDb.java
@@ -1,0 +1,86 @@
+package jpabook.jpashop;
+
+import jpabook.jpashop.domain.*;
+import jpabook.jpashop.domain.item.Book;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityManager;
+
+@Component
+@RequiredArgsConstructor
+public class InitDb {
+    private final InitService initService;
+
+    @PostConstruct
+    public void init(){
+        initService.dbInit1();
+        initService.dbInit2();
+    }
+
+    @Component
+    @Transactional
+    @RequiredArgsConstructor
+    static class InitService {
+        private final EntityManager em;
+        public void dbInit1(){
+            Member member = createMember("userA", "서울", "용산", "1011");
+            em.persist(member);
+
+            Book book = createBook("JPA1 Book", 10000, 100);
+            em.persist(book);
+
+            Book book2 = createBook("JPA2 Book", 20000, 100);
+            em.persist(book2);
+
+            OrderItem orderItem1 = OrderItem.createOrderItem(book, 10000, 1);
+            OrderItem orderItem2 = OrderItem.createOrderItem(book2, 20000, 2);
+
+            Delivery delivery = createDelivery(member);
+            Order order = Order.createOrder(member, delivery, orderItem1, orderItem2);
+            em.persist(order);
+        }
+
+        private static Delivery createDelivery(Member member) {
+            Delivery delivery = new Delivery();
+            delivery.setAddress(member.getAddress());
+            return delivery;
+        }
+
+        public void dbInit2() {
+            Member member = createMember("userB", "경기", "분당", "2022");
+            em.persist(member);
+
+            Book book = createBook("Spring1 Book", 20000, 200);
+            em.persist(book);
+            Book book2 = createBook("Spring2 Book", 40000, 300);
+            em.persist(book2);
+
+            OrderItem orderItem1 = OrderItem.createOrderItem(book, 20000, 3);
+            OrderItem orderItem2 = OrderItem.createOrderItem(book2, 40000, 4);
+
+            Delivery delivery = createDelivery(member);
+            Order order = Order.createOrder(member, delivery, orderItem1, orderItem2);
+            em.persist(order);
+        }
+
+        private static Book createBook(String JPA1_Book, int price, int stockQuantity) {
+            Book book = new Book();
+            book.setName(JPA1_Book);
+            book.setPrice(price);
+            book.setStockQuantity(stockQuantity);
+            return book;
+        }
+
+        private static Member createMember(String name, String city, String street, String zipcode) {
+            Member member = new Member();
+            member.setName(name);
+            member.setAddress(new Address(city, street, zipcode));
+            return member;
+        }
+    }
+
+
+}

--- a/jpashop/src/main/java/jpabook/jpashop/JpashopApplication.java
+++ b/jpashop/src/main/java/jpabook/jpashop/JpashopApplication.java
@@ -1,11 +1,20 @@
 package jpabook.jpashop;
 
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class JpashopApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(JpashopApplication.class, args);
+	}
+
+	@Bean
+	Hibernate5Module hibernate5Module(){
+		Hibernate5Module hibernate5Module = new Hibernate5Module();
+//		hibernate5Module.configure(Hibernate5Module.Feature.FORCE_LAZY_LOADING,true);
+		return hibernate5Module;
 	}
 }

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -1,0 +1,32 @@
+package jpabook.jpashop.api;
+
+import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.repository.OrderRepository;
+import jpabook.jpashop.repository.OrderSearch;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * xToOne (ManyToOne, OneToOne)
+ * Order
+ * Order -> Member
+ * Order -> Delivery
+ */
+@RestController
+@RequiredArgsConstructor
+public class OrderSimpleApiController {
+    private final OrderRepository orderRepository;
+
+    @GetMapping("/api/v1/simple-orders")
+    public List<Order> ordersv1(){
+        List<Order> all = orderRepository.findAllByCriteria(new OrderSearch());
+        for (Order order : all) {
+            order.getMember().getName(); //LAZY LOADING 이였던걸 강제 초기화
+            order.getDelivery().getAddress();
+        }
+        return all;
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/domain/Delivery.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/Delivery.java
@@ -10,6 +10,8 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -20,6 +22,7 @@ public class Delivery {
     @Column(name="delivery_id")
     private Long id;
 
+    @JsonIgnore
     @OneToOne(mappedBy = "delivery", fetch=LAZY)
     private Order order;
 

--- a/jpashop/src/main/java/jpabook/jpashop/domain/Member.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/Member.java
@@ -28,6 +28,7 @@ public class Member {
     @Embedded
     private Address address;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "member",fetch = LAZY)
     private List<Order> orders = new ArrayList<>();
 }

--- a/jpashop/src/main/java/jpabook/jpashop/domain/OrderItem.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/OrderItem.java
@@ -8,6 +8,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,6 +28,7 @@ public class OrderItem {
     private Item item;
 
     @ManyToOne(fetch=LAZY)
+    @JsonIgnore
     @JoinColumn(name="order_id")
     private Order order;
 

--- a/jpashop/src/main/resources/application.yml
+++ b/jpashop/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
     properties :
       hibernate:
 #        show_sql: true


### PR DESCRIPTION
this closes #17 
#주문 API V1
```java
/**
 *
 * xToOne(ManyToOne, OneToOne) 관계 최적화
 * Order
 * Order -> Member
 * Order -> Delivery
 *
 */
@RestController
@RequiredArgsConstructor
public class OrderSimpleApiController {
 private final OrderRepository orderRepository;
 /**
 * V1. 엔티티 직접 노출
 * - Hibernate5Module 모듈 등록, LAZY=null 처리
 * - 양방향 관계 문제 발생 -> @JsonIgnore
 */
 @GetMapping("/api/v1/simple-orders")
 public List<Order> ordersV1() {
 List<Order> all = orderRepository.findAllByString(new OrderSearch());
 for (Order order : all) {
 order.getMember().getName(); //Lazy 강제 초기화
 order.getDelivery().getAddress(); //Lazy 강제 초기환
 }
 return all;
 }
}
```

- 엔티티를 직접 노출하는 것을 좋지 않다.(앞장에서 이미 설명)
- `order` -> `member` 와 `order` -> `address` 는 지연로딩이다. 따라서 실제 엔티티 대신에 프록시 존재
- jackson 라이브러리는 기본적으로 이 프록시 객체를 json으로 어떻게 생성해야 하는지 모름 -> 예외 발생
- `Hibernate5Module` 을 스프링 빈으로 등록해서 해결(스프링 부트 사용시)
  - 기본적으로 초기화된 프록시 객체만 노출, 초기화 되지 않은 프록시 객체는 노출 안함

> 참고: 앞에서 계속 강조했듯이 정말 간단한 어플리케이션이 아니면 엔티티를 API 응답으로 외부로 노출하는 것은 좋지 않다! 따라서 `Hibernate5Module` 을 사용하기 보다는 DTO 로 변환하는 것이 더 좋은 방법이다.

> 주의: 지연 로딩(LAZY)를 피하기 위해 즉시로딩으로 설정하면 안된다. 즉시 로딩 때문에 연관관계가 필요 없는 경우에도 데이터를 항상 조회해서 성능 문제가 발생할 수 있다. 즉시 로딩으로 설정하면 성능 튜닝이 매우 어려워진다.
항상 지연 로딩을 기본으로 하고, 성능 최적화가 필요한 경우에는 페치조인(fetch join) 을 사용해라!(V3 에서 설명)
