### PR TITLE
Order API V2 개발

### DIFF
--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -1,13 +1,18 @@
 package jpabook.jpashop.api;
 
+import jpabook.jpashop.domain.Address;
 import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.domain.OrderStatus;
 import jpabook.jpashop.repository.OrderRepository;
 import jpabook.jpashop.repository.OrderSearch;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * xToOne (ManyToOne, OneToOne)
@@ -21,12 +26,38 @@ public class OrderSimpleApiController {
     private final OrderRepository orderRepository;
 
     @GetMapping("/api/v1/simple-orders")
-    public List<Order> ordersv1(){
+    public List<Order> ordersV1(){
         List<Order> all = orderRepository.findAllByCriteria(new OrderSearch());
         for (Order order : all) {
             order.getMember().getName(); //LAZY LOADING 이였던걸 강제 초기화
             order.getDelivery().getAddress();
         }
         return all;
+    }
+
+    @GetMapping("/api/v2/simple-orders")
+    public List<SimpleOrderDto> ordersV2(){
+        // N + 1 문제 -> 처음 order(2개) 조회하는 sql 쿼리 -> 회원,배송에 대한 쿼리 2개씩 총 4개의 쿼리가 더 나감.
+        List<Order> result = orderRepository.findAllByCriteria(new OrderSearch());
+        return result.stream()
+                .map(SimpleOrderDto::new)
+                .collect(Collectors.toList());
+    }
+
+    @Data
+    static class SimpleOrderDto{
+        private Long orderId;
+        private String name;
+        private LocalDateTime orderDate;
+        private OrderStatus orderStatus;
+        private Address address;
+
+        public SimpleOrderDto(Order order) {
+            orderId = order.getId();
+            name = order.getMember().getName(); //LAZY 초기화
+            orderDate = order.getOrderDate();
+            orderStatus = order.getStatus();
+            address= order.getDelivery().getAddress(); //LAZY 초기화
+        }
     }
 }


### PR DESCRIPTION
this closes #19 
# 간단한 주문 조회 V2 : 엔티티를 DTO 로 변환
```java
/**
 * V2. 엔티티를 조회해서 DTO로 변환(fetch join 사용X)
 * - 단점: 지연로딩으로 쿼리 N번 호출
 */
@GetMapping("/api/v2/simple-orders")
public List<SimpleOrderDto> ordersV2() {
 List<Order> orders = orderRepository.findAll();
 List<SimpleOrderDto> result = orders.stream()
 .map(o -> new SimpleOrderDto(o))
 .collect(toList());
 return result;
}
@Data
static class SimpleOrderDto {
 private Long orderId;
 private String name;
 private LocalDateTime orderDate; //주문시간
 private OrderStatus orderStatus;
 private Address address;
 public SimpleOrderDto(Order order) {
 orderId = order.getId();
 name = order.getMember().getName();
 orderDate = order.getOrderDate();
 orderStatus = order.getStatus();
 address = order.getDelivery().getAddress();
 }
}
```
- 엔티티를 DTO 로 변환하는 일반적인 방법이다.
- 쿼리가 총 1 + N + N 번 실행된다. (v1과 쿼리수 결과는 같다.)
  - `order` 조회 1번 ( order 조회 결과 수가 N이 된다.)
  - `order -> member` 지연 로딩 조회 N번
  - `order -> delivery` 지연 로딩 조회 N번
  - 예) order 결과가 4개면 최악의 경우 1 + 4 + 4번 실행된다.(최악의 경우)
    - 지연로딩은 영속성 컨텍스트에서 조회하므로, 이미 조회된 경우 쿼리를 생략한다.
> 의문점 : 영속성 컨텍스트는 @Transactional 이 끝나면 close 된다. 그런데 어떻게 dto 에서 `member.getName()` 조회를 하는 시점에 영속성 컨텍스트에 이미 조회된 값을 가져올 수가 있을까?
이점은 뒷 강의인 OSIV 편에서 볼 수 있다고 한다.