### PR TITLE
컬렉션 주문 조회 V3

### DIFF
--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -44,6 +44,17 @@ public class OrderApiController {
         return collect;
     }
 
+    @GetMapping("/api/v3/orders")
+    public List<OrderDto> ordersV3() {
+        List<Order> orders = orderRepository.findAllWithItem();
+
+        List<OrderDto> collect = orders.stream()
+                .map(o -> new OrderDto(o))
+                .collect(Collectors.toList());
+
+        return collect;
+    }
+
     @Data
     static class OrderDto {
         private Long orderId;

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -58,4 +58,14 @@ public class OrderRepository {
     public List<OrderSimpleQueryDto> findOrderDtos() {
         return em.createQuery("select new jpabook.jpashop.repository.OrderSimpleQueryDto(o.id,m.name,o.orderDate,o.status,d.address) from Order o join o.member m join o.delivery d", OrderSimpleQueryDto.class).getResultList();
     }
+
+    public List<Order> findAllWithItem() {
+        return em.createQuery(
+                "select distinct o from Order o " +
+                        "join fetch o.member m " +
+                        "join fetch o.delivery d " +
+                        "join fetch o.orderItems oi " +
+                        "join fetch oi.item i", Order.class
+        ).getResultList();
+    }
 }


### PR DESCRIPTION
this closes #27 

fetch join으로 N+1 문제를 해결
한 페치 조인 안에서 1개 초과하는 컬렉션을 사용하면 안된다.
페이징이 불가능하다. DB에서 조회되는 쿼리 결과는 order 2개일 시 총 데이터 4개이기 때문에 페이징이 불가해, 하이버네이트가 메모리를 이용해 페이징한다고 한다.