### PR TITLE
컬렉션 주문 조회V3.1 페이징 한계돌파

### DIFF
--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -10,6 +10,7 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
@@ -47,6 +48,18 @@ public class OrderApiController {
     @GetMapping("/api/v3/orders")
     public List<OrderDto> ordersV3() {
         List<Order> orders = orderRepository.findAllWithItem();
+
+        List<OrderDto> collect = orders.stream()
+                .map(o -> new OrderDto(o))
+                .collect(Collectors.toList());
+
+        return collect;
+    }
+
+    @GetMapping("/api/v3.1/orders")
+    public List<OrderDto> ordersV3_page(@RequestParam(value = "offset", defaultValue = "0") int offset,
+                                        @RequestParam(value = "limit", defaultValue = "100") int limit) {
+        List<Order> orders = orderRepository.findAllWithMemberDelivery(offset, limit);
 
         List<OrderDto> collect = orders.stream()
                 .map(o -> new OrderDto(o))

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -68,4 +68,11 @@ public class OrderRepository {
                         "join fetch oi.item i", Order.class
         ).getResultList();
     }
+
+    public List<Order> findAllWithMemberDelivery(int offset, int limit) {
+        return em.createQuery("select o from Order o join fetch o.member m join fetch o.delivery d",Order.class)
+                .setFirstResult(offset)
+                .setMaxResults(limit)
+                .getResultList();
+    }
 }

--- a/jpashop/src/main/resources/application.yml
+++ b/jpashop/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
       hibernate:
 #        show_sql: true
         format_sql: true
+        default_batch_fetch_size: 100
 
 logging:
   level:


### PR DESCRIPTION
this closes #29 
application.yml -> hibernate.default_batch_fetch_size 를 적용해 컬렉션이나 프록시 객체를 조회 시 정해둔 설정만큼
 IN 절로 쿼리문을 날려준다.

참고 #29 