### PR TITLE
컬렉션 주문 조회 V4

### DIFF
--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -6,6 +6,8 @@ import jpabook.jpashop.domain.OrderItem;
 import jpabook.jpashop.domain.OrderStatus;
 import jpabook.jpashop.repository.OrderRepository;
 import jpabook.jpashop.repository.OrderSearch;
+import jpabook.jpashop.repository.query.OrderQueryDto;
+import jpabook.jpashop.repository.query.OrderQueryRepository;
 import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ import java.util.stream.Collectors;
 public class OrderApiController {
 
     private final OrderRepository orderRepository;
+    private final OrderQueryRepository orderQueryRepository;
 
     @GetMapping("/api/v1/orders")
     public List<Order> ordersV1() {
@@ -66,6 +69,11 @@ public class OrderApiController {
                 .collect(Collectors.toList());
 
         return collect;
+    }
+
+    @GetMapping("/api/v4/orders")
+    public List<OrderQueryDto> ordersV4() {
+       return orderQueryRepository.findOrderQueryDtos();
     }
 
     @Data

--- a/jpashop/src/main/java/jpabook/jpashop/repository/query/OrderItemQueryDto.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/query/OrderItemQueryDto.java
@@ -1,0 +1,21 @@
+package jpabook.jpashop.repository.query;
+
+import lombok.Data;
+
+@Data
+public class OrderItemQueryDto {
+    private Long orderId;
+
+    private String itemName;
+
+    private int orderPrice;
+
+    private int count;
+
+    public OrderItemQueryDto(Long orderId, String itemName, int orderPrice, int count) {
+        this.orderId = orderId;
+        this.itemName = itemName;
+        this.orderPrice = orderPrice;
+        this.count = count;
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/repository/query/OrderQueryDto.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/query/OrderQueryDto.java
@@ -1,0 +1,31 @@
+package jpabook.jpashop.repository.query;
+
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.OrderStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+public class OrderQueryDto {
+    private Long orderId;
+
+    private String name;
+
+    private LocalDateTime orderDate;
+
+    private OrderStatus orderStatus;
+
+    private Address address;
+
+    private List<OrderItemQueryDto> orderItems;
+
+    public OrderQueryDto(Long orderId, String name, LocalDateTime orderDate, OrderStatus orderStatus, Address address) {
+        this.orderId = orderId;
+        this.name = name;
+        this.orderDate = orderDate;
+        this.orderStatus = orderStatus;
+        this.address = address;
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/repository/query/OrderQueryRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/query/OrderQueryRepository.java
@@ -1,0 +1,39 @@
+package jpabook.jpashop.repository.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderQueryRepository {
+    private final EntityManager em;
+
+
+    public List<OrderQueryDto> findOrderQueryDtos() {
+        List<OrderQueryDto> result = findOrders();
+
+        result.forEach(o -> {
+            List<OrderItemQueryDto> orderItems = findOrderItems(o.getOrderId());
+            o.setOrderItems(orderItems);
+        });
+        return result;
+    }
+
+    private List<OrderItemQueryDto> findOrderItems(Long orderId) {
+        return em.createQuery(
+                "select new jpabook.jpashop.repository.query.OrderItemQueryDto(oi.order.id, i.name, oi.orderPrice, oi.count) " +
+                        "from OrderItem oi " +
+                        "join oi.item i " +
+                        "where oi.order.id = :orderId",OrderItemQueryDto.class
+        ).setParameter("orderId", orderId).getResultList();
+    }
+
+    private List<OrderQueryDto> findOrders() {
+        return em.createQuery("select new jpabook.jpashop.repository.query.OrderQueryDto(o.id, m.name, o.orderDate, o.status, d.address) from Order o " +
+                "join o.member m " +
+                "join o.delivery d", OrderQueryDto.class).getResultList();
+    }
+}


### PR DESCRIPTION
this closes #31 

DTO로 직접 조회하는 쿼리문을 생성했다.
데이터의 수가 추가되지 않는 ToOne 관계는 한번에 조인해서 가져오고, 그 후 for문을 통해 컬렉션마다 각각 쿼리문을 날려서 생성한다. 1+N 문제가 발생

참고 #31 